### PR TITLE
fix: Update @testing-library/react for React 19 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "next": "15.3.3",
-    "@testing-library/react": "^14.0.0",
+    "@testing-library/react": "^15.0.0",
     "@testing-library/jest-dom": "^6.0.0"
   }
 }


### PR DESCRIPTION
This commit updates the version of `@testing-library/react` in `package.json` from `^14.0.0` to `^15.0.0`.

This change is necessary to resolve a peer dependency conflict with React 19 (your project uses `react@^19.0.0`). Version 14.x of `@testing-library/react` requires `react@^18.0.0`, which was causing an `ERESOLVE` error during the `npm install` phase of the Vercel build. Version 15.x of `@testing-library/react` supports React 19.

This update should allow the Vercel build to proceed without dependency resolution errors.