### PR TITLE
fix: Pin @testing-library/react to 15.0.0 for React 19

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "next": "15.3.3",
-    "@testing-library/react": "^15.0.0",
+    "@testing-library/react": "15.0.0",
     "@testing-library/jest-dom": "^6.0.0"
   }
 }


### PR DESCRIPTION
This commit pins the version of `@testing-library/react` in `package.json` to exactly `15.0.0`.

This change is a further attempt to resolve a persistent `ERESOLVE` peer dependency conflict with React 19 (your project uses `react@^19.0.0`). Previous attempts using `^15.0.0` (which resolved to 15.0.7) still erroneously reported a peer dependency on `react@^18.0.0` during Vercel builds.

Pinning to `15.0.0` ensures that the specific version intended for initial React 19 compatibility is used, aiming to bypass potential issues with patch versions or incorrect package metadata resolution in the build environment.