### PR TITLE
🧹 [Code Health] Remove unused MapDisplay commented-out import

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,6 @@ import styles from '../styles/Home.module.css';
 import dynamic from 'next/dynamic'; // Import dynamic
 import LocationInput from '../components/LocationInput';
 import WeatherDisplay from '../components/WeatherDisplay';
-// import MapDisplay from '../components/MapDisplay'; // Will be dynamically imported
 import FavoritesList from '../components/FavoritesList'; // Import FavoritesList
 import { useState, useEffect } from 'react'; // Import useEffect
 import { useI18n } from '../lib/i18n/i18nContext';


### PR DESCRIPTION
🎯 What:
Removed the commented-out import of `MapDisplay` in `pages/index.js`.

💡 Why:
This improves the code hygiene and maintainability of the codebase by eliminating dead, unused code.

✅ Verification:
The change is a simple comment removal, so it does not affect any application functionality.

✨ Result:
Cleaned up `pages/index.js`.

---
*PR created automatically by Jules for task [9684564900458680172](https://jules.google.com/task/9684564900458680172) started by @dieguesmosken*