### PR TITLE
🔒 Fix ReDoS vulnerability in translation interpolation

### DIFF
--- a/lib/i18n/i18nContext.js
+++ b/lib/i18n/i18nContext.js
@@ -9,7 +9,7 @@ export const I18nProvider = ({ children, defaultLang = 'pt' }) => {
   const t = (key, params = {}) => {
     let string = translations[language][key] || translations['en'][key] || key; // Fallback to English then key
     Object.keys(params).forEach(param => {
-      string = string.replace(new RegExp(`{{${param}}}`, 'g'), params[param]);
+      string = string.replaceAll(`{{${param}}}`, params[param]);
     });
     return string;
   };


### PR DESCRIPTION
🎯 **What:** Fixed a Regular Expression Denial of Service (ReDoS) vulnerability in the `t` translation interpolation function.

⚠️ **Risk:** The previous implementation used unsanitized parameters (object keys) directly in a dynamically constructed `RegExp` object. If an attacker controlled these keys (e.g., through malicious input payloads), they could construct strings that cause high CPU consumption and block the event loop, leading to a denial of service.

🛡️ **Solution:** Replaced `string.replace(new RegExp(...), ...)` with `string.replaceAll(..., ...)`. By providing a string literal to `replaceAll`, the parameter is evaluated as a raw string to be exactly matched rather than a regex pattern, completely eliminating the ReDoS vector without complex sanitization.

---
*PR created automatically by Jules for task [7757476315303458455](https://jules.google.com/task/7757476315303458455) started by @dieguesmosken*