### PR TITLE
🧪 Add error path test to Previsao page

### DIFF
--- a/__tests__/previsao.test.js
+++ b/__tests__/previsao.test.js
@@ -35,6 +35,18 @@ describe('Previsao Page', () => {
     expect(screen.getByText('Previsão de 7 Dias (Open-Meteo)')).toBeInTheDocument();
   });
 
+  it('displays an error message when fetch fails', async () => {
+    global.fetch.mockRejectedValueOnce(new Error('API Error Mock'));
+
+    await act(async () => {
+      render(<Previsao />);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('API Error Mock')).toBeInTheDocument();
+    });
+  });
+
   it('searches and displays forecast data', async () => {
     await act(async () => {
       render(<Previsao />);

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,3 @@
+🎯 **What:** Added an error path test in `previsao.test.js` to simulate a fetch failure and ensure the error message is displayed on the `Previsao` page.
+📊 **Coverage:** Covered the error state (`catch (err)`) when fetching forecast data, asserting that the corresponding error text renders appropriately.
+✨ **Result:** Improved test coverage by verifying that network or parsing errors during data fetching are handled gracefully and communicated to the user.


### PR DESCRIPTION
🎯 **What:** Added an error path test in `previsao.test.js` to simulate a fetch failure and ensure the error message is displayed on the `Previsao` page.
📊 **Coverage:** Covered the error state (`catch (err)`) when fetching forecast data, asserting that the corresponding error text renders appropriately.
✨ **Result:** Improved test coverage by verifying that network or parsing errors during data fetching are handled gracefully and communicated to the user.

---
*PR created automatically by Jules for task [3128844667328149308](https://jules.google.com/task/3128844667328149308) started by @dieguesmosken*