### PR TITLE
🔒 Fix mixed content security vulnerability

### DIFF
--- a/components/WeatherDisplay.js
+++ b/components/WeatherDisplay.js
@@ -38,7 +38,7 @@ export default function WeatherDisplay({ data, onAddToFavorites, isFavorited }) 
   if (data.weather && data.weather[0] && data.weather[0].icon) {
     const iconCode = data.weather[0].icon;
     if (/^[a-zA-Z0-9]+$/.test(iconCode)) {
-      weatherIcon = `http://openweathermap.org/img/wn/${iconCode}@2x.png`;
+      weatherIcon = `https://openweathermap.org/img/wn/${iconCode}@2x.png`;
     }
   }
 


### PR DESCRIPTION
🎯 **What:** Weather icons were loaded over insecure HTTP instead of HTTPS in `components/WeatherDisplay.js`.
⚠️ **Risk:** Mixed active content (loading HTTP resources on an HTTPS site) is generally blocked by modern browsers, leading to broken images. Additionally, HTTP traffic is sent in plaintext, meaning an attacker could theoretically intercept and modify the image, or track user activity if they were on an insecure network (Man-in-the-Middle attack).
🛡️ **Solution:** Updated the OpenWeatherMap icon URL from `http://` to `https://` to use a secure connection.

---
*PR created automatically by Jules for task [18396853753958121538](https://jules.google.com/task/18396853753958121538) started by @dieguesmosken*