### PR TITLE
🧪 [testing improvement: add error path test for Mapa page]

### DIFF
--- a/__tests__/mapa.test.js
+++ b/__tests__/mapa.test.js
@@ -31,4 +31,30 @@ describe('Mapa Page', () => {
 
     expect(screen.getByText('Mapa Meteorológico - INMET Capitais')).toBeInTheDocument();
   });
+
+  it('renders error message when fetch fails', async () => {
+    // Override the global fetch mock for this specific test
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve([])
+      })
+    ).mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+        json: () => Promise.resolve([])
+      })
+    );
+
+    await act(async () => {
+      render(
+        <I18nProvider>
+          <Mapa />
+        </I18nProvider>
+      );
+    });
+
+    // Wait for the error message to appear
+    expect(await screen.findByText('Erro: Failed to fetch INMET data')).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
🎯 **What:** The missing error path test for the Mapa page fetch operation has been added.
📊 **Coverage:** We now test the scenario where the INMET API fails to return a successful response, ensuring that the appropriate 'Erro' message is displayed to the user.
✨ **Result:** Test coverage for the `Mapa` component is improved, making the code more reliable against network or API failures.

---
*PR created automatically by Jules for task [7071589728931466312](https://jules.google.com/task/7071589728931466312) started by @dieguesmosken*