### PR TITLE
Fix default marker icon issue by using local imports in Leaflet Map components

### DIFF
--- a/components/Map.js
+++ b/components/Map.js
@@ -3,12 +3,16 @@ import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import 'leaflet/dist/leaflet.css';
 import L from 'leaflet';
 
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
 // Fix for default marker icons in Leaflet when using Webpack/Next.js
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
-  iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
-  shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
+  iconRetinaUrl: iconRetinaUrl.src || iconRetinaUrl,
+  iconUrl: iconUrl.src || iconUrl,
+  shadowUrl: shadowUrl.src || shadowUrl,
 });
 
 const capitalCoordinates = {

--- a/components/MapDisplay.js
+++ b/components/MapDisplay.js
@@ -3,12 +3,16 @@ import { MapContainer, TileLayer, Marker, Popup } from 'react-leaflet';
 import L from 'leaflet'; // Import Leaflet to fix marker icon issue
 import { useI18n } from '../lib/i18n/i18nContext';
 
+import iconRetinaUrl from 'leaflet/dist/images/marker-icon-2x.png';
+import iconUrl from 'leaflet/dist/images/marker-icon.png';
+import shadowUrl from 'leaflet/dist/images/marker-shadow.png';
+
 // Fix for default marker icon issue with Webpack
 delete L.Icon.Default.prototype._getIconUrl;
 L.Icon.Default.mergeOptions({
-  iconRetinaUrl: 'https://unpkg.com/leaflet@1.7.1/dist/images/marker-icon-2x.png',
-  iconUrl: 'https://unpkg.com/leaflet@1.7.1/dist/images/marker-icon.png',
-  shadowUrl: 'https://unpkg.com/leaflet@1.7.1/dist/images/marker-shadow.png',
+  iconRetinaUrl: iconRetinaUrl.src || iconRetinaUrl,
+  iconUrl: iconUrl.src || iconUrl,
+  shadowUrl: shadowUrl.src || shadowUrl,
 });
 
 const MapDisplay = ({ latitude, longitude, zoom }) => {


### PR DESCRIPTION
Replaces hardcoded external CDN links for default leaflet marker
icons in MapDisplay.js and Map.js with local package imports,
using the '.src' resolution for Webpack compatibility. This removes the dependency on external sites for core functionality, ensuring that users with restricted network access or offline development can still see markers correctly on the map.

---
*PR created automatically by Jules for task [10534457188445982855](https://jules.google.com/task/10534457188445982855) started by @dieguesmosken*