### PR TITLE
Translate 'Loading map...' text in MapDisplay

### DIFF
--- a/components/MapDisplay.js
+++ b/components/MapDisplay.js
@@ -15,7 +15,7 @@ const MapDisplay = ({ latitude, longitude, zoom }) => {
   const { t } = useI18n();
 
   if (typeof latitude === 'undefined' || typeof longitude === 'undefined') {
-    return <p>Loading map...</p>; // Consider translating this too if it's user-visible for long
+    return <p>{t('loadingMap')}</p>;
   }
 
   const position = [latitude, longitude];

--- a/lib/i18n/translations.js
+++ b/lib/i18n/translations.js
@@ -34,7 +34,8 @@ export const translations = {
     favorites: 'Favorites',
     noFavoritesYet: 'No favorite cities yet. Add some!',
     cityAlreadyFavorited: 'City is already in favorites.',
-    mapTitle: 'Location Map'
+    mapTitle: 'Location Map',
+    loadingMap: 'Loading map...'
   },
   pt: {
     weatherForecaster: 'Previsão do Tempo',
@@ -71,6 +72,7 @@ export const translations = {
     favorites: 'Favoritos',
     noFavoritesYet: 'Nenhuma cidade favorita ainda. Adicione algumas!',
     cityAlreadyFavorited: 'Cidade já está nos favoritos.',
-    mapTitle: 'Mapa da Localização'
+    mapTitle: 'Mapa da Localização',
+    loadingMap: 'Carregando mapa...'
   },
 };


### PR DESCRIPTION
Replaces the hardcoded "Loading map..." string in `MapDisplay.js` with the translated value from `useI18n`. The corresponding English ("Loading map...") and Portuguese ("Carregando mapa...") translations have been added to the i18n dictionaries.

Testing: Verified visually using playwright. `npm run build` and `npx jest` succeed.

---
*PR created automatically by Jules for task [3550041629942970430](https://jules.google.com/task/3550041629942970430) started by @dieguesmosken*