### PR TITLE
🧹 Remove unused API route template

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `pages/index.js`. The page auto-updates as you edit the file.
 
-[API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) can be accessed on [http://localhost:3000/api/hello](http://localhost:3000/api/hello). This endpoint can be edited in `pages/api/hello.js`.
-
-The `pages/api` directory is mapped to `/api/*`. Files in this directory are treated as [API routes](https://nextjs.org/docs/pages/building-your-application/routing/api-routes) instead of React pages.
-
 This project uses [`next/font`](https://nextjs.org/docs/pages/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/pages/api/hello.js
+++ b/pages/api/hello.js
@@ -1,5 +1,0 @@
-// Next.js API route support: https://nextjs.org/docs/api-routes/introduction
-
-export default function handler(req, res) {
-  res.status(200).json({ hello: "World" });
-}


### PR DESCRIPTION
🎯 **What:** Deleted `pages/api/hello.js` and removed its references from `README.md`.
💡 **Why:** This was an unused API route template generated by Next.js. Removing it improves code health by eliminating dead code and unnecessary boilerplate.
✅ **Verification:** Verified by running `npm run build` and `npx jest` to ensure no functionality is broken and all tests pass.
✨ **Result:** A cleaner codebase with less dead code and outdated documentation.

---
*PR created automatically by Jules for task [4393202920705636846](https://jules.google.com/task/4393202920705636846) started by @dieguesmosken*